### PR TITLE
Define HealthCheck and add debug logging flag

### DIFF
--- a/src/components/admin/ApiHealthDashboard.tsx
+++ b/src/components/admin/ApiHealthDashboard.tsx
@@ -16,6 +16,17 @@ import {
   RefreshCw
 } from 'lucide-react';
 
+const debug = import.meta.env.DEV;
+
+interface HealthCheck {
+  service_name: string;
+  is_healthy: boolean;
+  status_code: number;
+  response_time_ms: number;
+  error_message: string | null;
+  checked_at: string;
+}
+
 interface HealthSummary {
   service_name: string;
   is_enabled: boolean;
@@ -37,7 +48,7 @@ interface SecretsStatus {
 const ApiHealthDashboard = () => {
   const { getHealthStatus, getSecretsStatus, testApiKey, loading } = useApiProxy();
   const [healthData, setHealthData] = useState<{
-    health_checks: any[];
+    health_checks: HealthCheck[];
     summary: HealthSummary[];
   } | null>(null);
   const [secretsData, setSecretsData] = useState<{
@@ -70,7 +81,7 @@ const ApiHealthDashboard = () => {
   const handleTestApiKey = async (service: string) => {
     try {
       const result = await testApiKey(service);
-      console.log('API key test result:', result);
+      if (debug) console.log('API key test result:', result);
       // Refresh data after test
       await fetchData();
     } catch (error) {

--- a/src/components/widgets/BreakingNewsBanner.tsx
+++ b/src/components/widgets/BreakingNewsBanner.tsx
@@ -19,6 +19,7 @@ export const BreakingNewsBanner = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { makeRequest } = useApiProxy();
+  const debug = import.meta.env.DEV;
 
   useEffect(() => {
     const fetchBreakingNews = async () => {
@@ -28,15 +29,15 @@ export const BreakingNewsBanner = () => {
 
         // Try RSS feeds first via edge function (fast, no API rate limits)
         try {
-          console.log('🔄 Fetching breaking news from RSS...');
+          if (debug) console.log('🔄 Fetching breaking news from RSS...');
           const { data: rssData } = await supabase.functions.invoke('rss-fetcher', {
             body: { sources: ['ap'], limit: 20 }
           });
 
-          console.log('📰 RSS Data received:', rssData);
+          if (debug) console.log('📰 RSS Data received:', rssData);
 
           if (rssData?.success && rssData.items?.length) {
-            console.log(`✅ Found ${rssData.items.length} RSS items`);
+            if (debug) console.log(`✅ Found ${rssData.items.length} RSS items`);
             const breakingNews: BreakingNewsItem[] = rssData.items
               .slice(0, 10)
               .map((item: any, index: number) => ({
@@ -48,11 +49,11 @@ export const BreakingNewsBanner = () => {
                 isBreaking: true,
               }));
 
-            console.log('🎯 Setting breaking news:', breakingNews);
+            if (debug) console.log('🎯 Setting breaking news:', breakingNews);
             setNews(breakingNews);
             return; // Done if RSS succeeded
           } else {
-            console.log('⚠️ RSS data invalid or empty');
+            if (debug) console.log('⚠️ RSS data invalid or empty');
           }
         } catch (rssError) {
           console.error('❌ RSS fetch error:', rssError);

--- a/src/components/widgets/NewsWidget.tsx
+++ b/src/components/widgets/NewsWidget.tsx
@@ -83,6 +83,7 @@ export const NewsWidget: React.FC<NewsWidgetProps> = ({ onRemove }) => {
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [activeTab, setActiveTab] = useState('headlines');
   const [showFilters, setShowFilters] = useState(false);
+  const debug = import.meta.env.DEV;
 
   // Fetch news based on current filters
   const fetchNews = async () => {
@@ -113,7 +114,7 @@ export const NewsWidget: React.FC<NewsWidgetProps> = ({ onRemove }) => {
         delete params.category;
       }
 
-      console.log('Fetching news with params:', params);
+      if (debug) console.log('Fetching news with params:', params);
 
       const response = await makeRequest({
         service: 'news',

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -138,6 +138,7 @@ export const WeatherWidget: React.FC<WeatherWidgetProps> = ({ onRemove }) => {
   const [activeTab, setActiveTab] = useState('current');
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [useFahrenheit, setUseFahrenheit] = useState(true);
+  const debug = import.meta.env.DEV;
 
   // Convert temperature between Celsius and Fahrenheit
   const convertTemp = (temp: number, toFahrenheit: boolean) => {
@@ -282,7 +283,7 @@ export const WeatherWidget: React.FC<WeatherWidgetProps> = ({ onRemove }) => {
         }
       } catch (alertError) {
         // Alerts API might not be available for all locations
-        console.log('Weather alerts not available for this location');
+        if (debug) console.log('Weather alerts not available for this location');
       }
 
       const processedData: WeatherData = {

--- a/src/hooks/useClockConfig.tsx
+++ b/src/hooks/useClockConfig.tsx
@@ -31,6 +31,7 @@ export const useClockConfig = () => {
   const [clockSettings, setClockSettings] = useState<ClockSettings>(defaultClockSettings);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
+  const debug = import.meta.env.DEV;
 
   // Load clock configuration
   useEffect(() => {
@@ -87,7 +88,7 @@ export const useClockConfig = () => {
       if (error) throw error;
 
       setClockSettings(newSettings);
-      console.log('Clock settings saved successfully');
+      if (debug) console.log('Clock settings saved successfully');
     } catch (error: any) {
       console.error('Error saving clock settings:', error);
       toast({

--- a/src/hooks/useHoustonTraffic.tsx
+++ b/src/hooks/useHoustonTraffic.tsx
@@ -41,6 +41,7 @@ export const useHoustonTraffic = () => {
   const [isLoadingMetro, setIsLoadingMetro] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const debug = import.meta.env.DEV;
 
   // Fetch traffic incidents from database
   const fetchTrafficIncidents = async () => {
@@ -90,7 +91,7 @@ export const useHoustonTraffic = () => {
   const refreshData = async () => {
     try {
       setError(null);
-      console.log('Refreshing Houston traffic data...');
+      if (debug) console.log('Refreshing Houston traffic data...');
 
       const { data, error } = await supabase.functions.invoke('houston-traffic', {
         body: { action: 'fetch' }
@@ -98,7 +99,7 @@ export const useHoustonTraffic = () => {
 
       if (error) throw error;
 
-      console.log('Traffic data refresh response:', data);
+      if (debug) console.log('Traffic data refresh response:', data);
       
       // After successful refresh, fetch updated data from database
       await Promise.all([

--- a/src/hooks/useSports.tsx
+++ b/src/hooks/useSports.tsx
@@ -44,6 +44,7 @@ export const useSports = () => {
   const { makeRequest } = useApiProxy();
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const debug = import.meta.env.DEV;
 
   const defaultConfig = {
     favoriteTeams: ['Astros', 'Texans', 'Rockets', 'Lightning'],
@@ -193,7 +194,7 @@ export const useSports = () => {
       }
       
       // Debug: Log some sample events to see team names
-      console.log('Sample sports events:', allEvents.slice(0, 5));
+      if (debug) console.log('Sample sports events:', allEvents.slice(0, 5));
       
       // Sort by date (upcoming first, then recent) and return latest 20 events
       return allEvents

--- a/src/hooks/useTexasLonghorns.tsx
+++ b/src/hooks/useTexasLonghorns.tsx
@@ -15,8 +15,9 @@ interface LonghornsData {
 }
 
 export const useTexasLonghorns = () => {
+  const debug = import.meta.env.DEV;
   const fetchLonghornsNews = async (): Promise<LonghornsData> => {
-    console.log('🏈 Fetching Texas Longhorns football news...');
+    if (debug) console.log('🏈 Fetching Texas Longhorns football news...');
     
     try {
       const { data, error } = await supabase.functions.invoke('rss-fetcher', {
@@ -28,7 +29,7 @@ export const useTexasLonghorns = () => {
 
       if (error) throw error;
 
-      console.log('🏈 Longhorns data received:', data);
+      if (debug) console.log('🏈 Longhorns data received:', data);
       return data;
     } catch (error) {
       console.error('Error fetching Longhorns news:', error);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+const debug = import.meta.env.DEV;
 
-console.log("React version:", React.version);
+if (debug) console.log("React version:", React.version);
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/supabase/functions/api-proxy/index.ts
+++ b/supabase/functions/api-proxy/index.ts
@@ -6,6 +6,8 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
+const DEBUG = Deno.env.get('DEBUG') === 'true';
+
 interface ApiServiceConfig {
   service_name: string;
   base_url: string;
@@ -52,7 +54,7 @@ serve(async (req) => {
       throw new Error('Service and endpoint are required');
     }
 
-    console.log(`API Proxy request: ${service} - ${endpoint} for user ${user.id}`);
+    if (DEBUG) console.log(`API Proxy request: ${service} - ${endpoint} for user ${user.id}`);
 
     // Get service configuration
     const { data: serviceConfig, error: configError } = await supabase
@@ -123,7 +125,7 @@ serve(async (req) => {
       .single() as { data: CacheEntry | null };
 
     if (cachedData) {
-      console.log(`Cache hit for ${service} - ${endpoint}`);
+      if (DEBUG) console.log(`Cache hit for ${service} - ${endpoint}`);
       return new Response(JSON.stringify({
         success: true,
         data: cachedData.data,
@@ -191,7 +193,7 @@ serve(async (req) => {
       fullUrl += `?${urlParams.toString()}`;
     }
 
-    console.log(`Making API request to: ${fullUrl}`);
+    if (DEBUG) console.log(`Making API request to: ${fullUrl}`);
 
     // Make the API request with timeout
     const controller = new AbortController();
@@ -267,7 +269,7 @@ serve(async (req) => {
       expires_at: expiresAt.toISOString(),
     });
 
-    console.log(`Successful API response for ${service} - ${endpoint} (${responseTime}ms)`);
+    if (DEBUG) console.log(`Successful API response for ${service} - ${endpoint} (${responseTime}ms)`);
 
     return new Response(JSON.stringify({
       success: true,

--- a/supabase/functions/health-monitor/index.ts
+++ b/supabase/functions/health-monitor/index.ts
@@ -13,6 +13,8 @@ interface ApiServiceConfig {
   timeout_seconds: number;
 }
 
+const DEBUG = Deno.env.get('DEBUG') === 'true';
+
 serve(async (req) => {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
@@ -29,7 +31,7 @@ serve(async (req) => {
     const action = url.searchParams.get('action') || 'check-all';
     const service = url.searchParams.get('service');
 
-    console.log(`Health monitor action: ${action}`);
+    if (DEBUG) console.log(`Health monitor action: ${action}`);
 
     if (action === 'check-all') {
       // Get all enabled services

--- a/supabase/functions/houston-traffic/index.ts
+++ b/supabase/functions/houston-traffic/index.ts
@@ -15,6 +15,8 @@ const supabase = createClient(supabaseUrl, supabaseServiceKey);
 // API Keys
 const googleMapsApiKey = Deno.env.get('GOOGLE_MAPS_API_KEY');
 
+const DEBUG = Deno.env.get('DEBUG') === 'true';
+
 interface TrafficIncident {
   title: string;
   description?: string;
@@ -45,7 +47,7 @@ interface MetroAlert {
 // Fetch Houston Metro alerts
 async function fetchMetroAlerts(): Promise<MetroAlert[]> {
   try {
-    console.log('Fetching Houston Metro alerts...');
+    if (DEBUG) console.log('Fetching Houston Metro alerts...');
     
     // Houston Metro doesn't have a public API, so we'll simulate some alerts for now
     // In production, you would scrape their website or find alternative data sources
@@ -63,7 +65,7 @@ async function fetchMetroAlerts(): Promise<MetroAlert[]> {
       }
     ];
     
-    console.log(`Found ${mockAlerts.length} Metro alerts (simulated)`);
+    if (DEBUG) console.log(`Found ${mockAlerts.length} Metro alerts (simulated)`);
     return mockAlerts;
   } catch (error) {
     console.error('Error fetching Metro alerts:', error);
@@ -74,12 +76,12 @@ async function fetchMetroAlerts(): Promise<MetroAlert[]> {
 // Fetch traffic incidents from Google Maps
 async function fetchGoogleTrafficIncidents(): Promise<TrafficIncident[]> {
   if (!googleMapsApiKey) {
-    console.log('Google Maps API key not configured, skipping traffic incidents');
+    if (DEBUG) console.log('Google Maps API key not configured, skipping traffic incidents');
     return [];
   }
 
   try {
-    console.log('Fetching Google Maps traffic data...');
+    if (DEBUG) console.log('Fetching Google Maps traffic data...');
     
     // Google Maps doesn't have a direct traffic incidents API
     // We'll use Places API to find points of interest and simulate incidents
@@ -134,7 +136,7 @@ async function fetchGoogleTrafficIncidents(): Promise<TrafficIncident[]> {
       }
     ];
     
-    console.log(`Found ${mockIncidents.length} traffic incidents (simulated)`);
+    if (DEBUG) console.log(`Found ${mockIncidents.length} traffic incidents (simulated)`);
     return mockIncidents;
   } catch (error) {
     console.error('Error fetching Google traffic data:', error);
@@ -147,7 +149,7 @@ async function storeTrafficIncidents(incidents: TrafficIncident[]) {
   if (incidents.length === 0) return;
 
   try {
-    console.log(`Storing ${incidents.length} traffic incidents...`);
+    if (DEBUG) console.log(`Storing ${incidents.length} traffic incidents...`);
     
     for (const incident of incidents) {
       // Check if incident already exists
@@ -175,7 +177,7 @@ async function storeTrafficIncidents(incidents: TrafficIncident[]) {
         if (error) {
           console.error('Error updating traffic incident:', error);
         } else {
-          console.log(`Updated traffic incident: ${incident.title}`);
+          if (DEBUG) console.log(`Updated traffic incident: ${incident.title}`);
         }
       } else {
         // Insert new incident
@@ -198,7 +200,7 @@ async function storeTrafficIncidents(incidents: TrafficIncident[]) {
         if (error) {
           console.error('Error inserting traffic incident:', error);
         } else {
-          console.log(`Inserted new traffic incident: ${incident.title}`);
+          if (DEBUG) console.log(`Inserted new traffic incident: ${incident.title}`);
         }
       }
     }
@@ -212,7 +214,7 @@ async function storeMetroAlerts(alerts: MetroAlert[]) {
   if (alerts.length === 0) return;
 
   try {
-    console.log(`Storing ${alerts.length} Metro alerts...`);
+    if (DEBUG) console.log(`Storing ${alerts.length} Metro alerts...`);
     
     for (const alert of alerts) {
       // Check if alert already exists
@@ -240,7 +242,7 @@ async function storeMetroAlerts(alerts: MetroAlert[]) {
         if (error) {
           console.error('Error updating Metro alert:', error);
         } else {
-          console.log(`Updated Metro alert: ${alert.title}`);
+          if (DEBUG) console.log(`Updated Metro alert: ${alert.title}`);
         }
       } else {
         // Insert new alert
@@ -262,7 +264,7 @@ async function storeMetroAlerts(alerts: MetroAlert[]) {
         if (error) {
           console.error('Error inserting Metro alert:', error);
         } else {
-          console.log(`Inserted new Metro alert: ${alert.title}`);
+          if (DEBUG) console.log(`Inserted new Metro alert: ${alert.title}`);
         }
       }
     }
@@ -281,7 +283,7 @@ serve(async (req) => {
     const url = new URL(req.url);
     const action = url.searchParams.get('action') || 'fetch';
 
-    console.log(`Houston Traffic API called with action: ${action}`);
+    if (DEBUG) console.log(`Houston Traffic API called with action: ${action}`);
 
     if (action === 'fetch') {
       // Fetch traffic data from all sources

--- a/supabase/functions/manage-secrets/index.ts
+++ b/supabase/functions/manage-secrets/index.ts
@@ -6,6 +6,8 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
+const DEBUG = Deno.env.get('DEBUG') === 'true';
+
 serve(async (req) => {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
@@ -35,7 +37,7 @@ serve(async (req) => {
     const url = new URL(req.url);
     const action = url.searchParams.get('action') || 'list';
 
-    console.log(`Manage secrets action: ${action} for user ${user.id}`);
+    if (DEBUG) console.log(`Manage secrets action: ${action} for user ${user.id}`);
 
     if (action === 'list') {
       // List available API services and their secret requirements


### PR DESCRIPTION
## Summary
- add `HealthCheck` interface and type `health_checks` accordingly
- wrap console.log usage behind debug flags across client and server

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c5056f6c8322812f549b1f3244d6