### PR TITLE
feat: add lightweight logger and replace console.log

### DIFF
--- a/src/components/admin/ApiHealthDashboard.tsx
+++ b/src/components/admin/ApiHealthDashboard.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import logger from '@/lib/logger';
 import { 
   Activity, 
   CheckCircle, 
@@ -70,7 +71,7 @@ const ApiHealthDashboard = () => {
   const handleTestApiKey = async (service: string) => {
     try {
       const result = await testApiKey(service);
-      console.log('API key test result:', result);
+      logger.debug('API key test result:', result);
       // Refresh data after test
       await fetchData();
     } catch (error) {

--- a/src/components/widgets/BreakingNewsBanner.tsx
+++ b/src/components/widgets/BreakingNewsBanner.tsx
@@ -4,6 +4,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { ExternalLink, AlertCircle } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
+import logger from '@/lib/logger';
 
 interface BreakingNewsItem {
   id: string;
@@ -28,15 +29,15 @@ export const BreakingNewsBanner = () => {
 
         // Try RSS feeds first via edge function (fast, no API rate limits)
         try {
-          console.log('🔄 Fetching breaking news from RSS...');
+          logger.debug('🔄 Fetching breaking news from RSS...');
           const { data: rssData } = await supabase.functions.invoke('rss-fetcher', {
             body: { sources: ['ap'], limit: 20 }
           });
 
-          console.log('📰 RSS Data received:', rssData);
+          logger.debug('📰 RSS Data received:', rssData);
 
           if (rssData?.success && rssData.items?.length) {
-            console.log(`✅ Found ${rssData.items.length} RSS items`);
+            logger.debug(`✅ Found ${rssData.items.length} RSS items`);
             const breakingNews: BreakingNewsItem[] = rssData.items
               .slice(0, 10)
               .map((item: any, index: number) => ({
@@ -48,11 +49,11 @@ export const BreakingNewsBanner = () => {
                 isBreaking: true,
               }));
 
-            console.log('🎯 Setting breaking news:', breakingNews);
+            logger.debug('🎯 Setting breaking news:', breakingNews);
             setNews(breakingNews);
             return; // Done if RSS succeeded
           } else {
-            console.log('⚠️ RSS data invalid or empty');
+            logger.debug('⚠️ RSS data invalid or empty');
           }
         } catch (rssError) {
           console.error('❌ RSS fetch error:', rssError);

--- a/src/components/widgets/NewsWidget.tsx
+++ b/src/components/widgets/NewsWidget.tsx
@@ -8,6 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import logger from '@/lib/logger';
 import { 
   Newspaper, 
   Search, 
@@ -113,7 +114,7 @@ export const NewsWidget: React.FC<NewsWidgetProps> = ({ onRemove }) => {
         delete params.category;
       }
 
-      console.log('Fetching news with params:', params);
+      logger.debug('Fetching news with params:', params);
 
       const response = await makeRequest({
         service: 'news',

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useApiProxy } from '@/hooks/useApiProxy';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import logger from '@/lib/logger';
 import { 
   Cloud, 
   Sun, 
@@ -282,7 +283,7 @@ export const WeatherWidget: React.FC<WeatherWidgetProps> = ({ onRemove }) => {
         }
       } catch (alertError) {
         // Alerts API might not be available for all locations
-        console.log('Weather alerts not available for this location');
+        logger.debug('Weather alerts not available for this location');
       }
 
       const processedData: WeatherData = {

--- a/src/hooks/useClockConfig.tsx
+++ b/src/hooks/useClockConfig.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from './useAuth';
 import { useToast } from './use-toast';
+import logger from '@/lib/logger';
 
 export interface SavedTimeZoneConfig {
   id: string;
@@ -87,7 +88,7 @@ export const useClockConfig = () => {
       if (error) throw error;
 
       setClockSettings(newSettings);
-      console.log('Clock settings saved successfully');
+      logger.debug('Clock settings saved successfully');
     } catch (error: any) {
       console.error('Error saving clock settings:', error);
       toast({

--- a/src/hooks/useHoustonTraffic.tsx
+++ b/src/hooks/useHoustonTraffic.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import logger from '@/lib/logger';
 
 interface TrafficIncident {
   id: string;
@@ -90,7 +91,7 @@ export const useHoustonTraffic = () => {
   const refreshData = async () => {
     try {
       setError(null);
-      console.log('Refreshing Houston traffic data...');
+      logger.debug('Refreshing Houston traffic data...');
 
       const { data, error } = await supabase.functions.invoke('houston-traffic', {
         body: { action: 'fetch' }
@@ -98,7 +99,7 @@ export const useHoustonTraffic = () => {
 
       if (error) throw error;
 
-      console.log('Traffic data refresh response:', data);
+      logger.debug('Traffic data refresh response:', data);
       
       // After successful refresh, fetch updated data from database
       await Promise.all([

--- a/src/hooks/useSports.tsx
+++ b/src/hooks/useSports.tsx
@@ -3,6 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from './useAuth';
 import { useApiProxy } from './useApiProxy';
 import { useToast } from '@/hooks/use-toast';
+import logger from '@/lib/logger';
 
 interface SportsData {
   idEvent: string;
@@ -193,7 +194,7 @@ export const useSports = () => {
       }
       
       // Debug: Log some sample events to see team names
-      console.log('Sample sports events:', allEvents.slice(0, 5));
+      logger.debug('Sample sports events:', allEvents.slice(0, 5));
       
       // Sort by date (upcoming first, then recent) and return latest 20 events
       return allEvents

--- a/src/hooks/useTexasLonghorns.tsx
+++ b/src/hooks/useTexasLonghorns.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import logger from '@/lib/logger';
 
 interface LonghornsArticle {
   title: string;
@@ -16,7 +17,7 @@ interface LonghornsData {
 
 export const useTexasLonghorns = () => {
   const fetchLonghornsNews = async (): Promise<LonghornsData> => {
-    console.log('🏈 Fetching Texas Longhorns football news...');
+    logger.debug('🏈 Fetching Texas Longhorns football news...');
     
     try {
       const { data, error } = await supabase.functions.invoke('rss-fetcher', {
@@ -28,7 +29,7 @@ export const useTexasLonghorns = () => {
 
       if (error) throw error;
 
-      console.log('🏈 Longhorns data received:', data);
+      logger.debug('🏈 Longhorns data received:', data);
       return data;
     } catch (error) {
       console.error('Error fetching Longhorns news:', error);

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,24 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const levelOrder: LogLevel[] = ['debug', 'info', 'warn', 'error'];
+const currentLevel: LogLevel = import.meta.env.DEV ? 'debug' : 'info';
+
+function shouldLog(level: LogLevel) {
+  return levelOrder.indexOf(level) >= levelOrder.indexOf(currentLevel);
+}
+
+function log(level: LogLevel, ...args: any[]) {
+  if (!shouldLog(level)) return;
+  const method = level === 'debug' ? 'debug' : level;
+  // eslint-disable-next-line no-console
+  console[method](...args);
+}
+
+const logger = {
+  debug: (...args: any[]) => log('debug', ...args),
+  info: (...args: any[]) => log('info', ...args),
+  warn: (...args: any[]) => log('warn', ...args),
+  error: (...args: any[]) => log('error', ...args),
+};
+
+export default logger;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import logger from "@/lib/logger";
 
-console.log("React version:", React.version);
+logger.debug("React version:", React.version);
 
 createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
## Summary
- add lightweight logger with log levels; debug logs only output in development
- replace console.log with logger.debug across hooks and widgets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6c6149d548322815526ec0f842664