### PR TITLE
feat: centralize hook error reporting

### DIFF
--- a/src/hooks/useClockConfig.tsx
+++ b/src/hooks/useClockConfig.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from './useAuth';
 import { useToast } from './use-toast';
+import { logError } from '@/lib/logError';
 
 export interface SavedTimeZoneConfig {
   id: string;
@@ -49,7 +50,7 @@ export const useClockConfig = () => {
           .maybeSingle();
 
         if (error) {
-          console.error('Error loading clock config:', error);
+          logError('Error loading clock config:', error);
           setClockSettings(defaultClockSettings);
         } else if (data && (data as any).clock_settings) {
           const settings = (data as any).clock_settings as ClockSettings;
@@ -58,7 +59,7 @@ export const useClockConfig = () => {
           setClockSettings(defaultClockSettings);
         }
       } catch (error) {
-        console.error('Error loading clock config:', error);
+        logError('Error loading clock config:', error);
         setClockSettings(defaultClockSettings);
       } finally {
         setIsLoading(false);
@@ -89,12 +90,7 @@ export const useClockConfig = () => {
       setClockSettings(newSettings);
       console.log('Clock settings saved successfully');
     } catch (error: any) {
-      console.error('Error saving clock settings:', error);
-      toast({
-        title: "Error saving clock settings",
-        description: error?.message || "Failed to save your clock settings.",
-        variant: "destructive",
-      });
+      logError('Error saving clock settings:', error);
     } finally {
       setIsSaving(false);
     }

--- a/src/hooks/useCryptocurrency.tsx
+++ b/src/hooks/useCryptocurrency.tsx
@@ -3,6 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from './useAuth';
 import { useApiProxy } from './useApiProxy';
 import { useToast } from './use-toast';
+import { logError } from '@/lib/logError';
 
 interface CryptoData {
   id: string;
@@ -42,7 +43,7 @@ export const useCryptocurrency = () => {
         .limit(1);
       
       if (error) {
-        console.error('Error fetching crypto config:', error);
+        logError('Error fetching crypto config:', error);
         return { currencies: defaultCrypto };
       }
       
@@ -83,7 +84,7 @@ export const useCryptocurrency = () => {
         });
       }
     } catch (error) {
-      console.error('Error fetching crypto data:', error);
+      logError('Error fetching crypto data:', error);
     }
     
     return [];

--- a/src/hooks/useCustomCities.tsx
+++ b/src/hooks/useCustomCities.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from './useAuth';
 import { useToast } from './use-toast';
+import { logError } from '@/lib/logError';
 
 export interface CustomCity {
   id: string;
@@ -32,22 +33,12 @@ export const useCustomCities = () => {
           .order('created_at', { ascending: true });
 
         if (error) {
-          console.error('Error loading custom cities:', error);
-          toast({
-            title: "Error loading custom cities",
-            description: error.message,
-            variant: "destructive",
-          });
+          logError('Error loading custom cities:', error);
         } else {
           setCustomCities(data || []);
         }
       } catch (error: any) {
-        console.error('Error loading custom cities:', error);
-        toast({
-          title: "Error loading custom cities",
-          description: error.message,
-          variant: "destructive",
-        });
+        logError('Error loading custom cities:', error);
       } finally {
         setIsLoading(false);
       }
@@ -102,12 +93,7 @@ export const useCustomCities = () => {
       });
       return true;
     } catch (error: any) {
-      console.error('Error adding custom city:', error);
-      toast({
-        title: "Error adding city",
-        description: error.message,
-        variant: "destructive",
-      });
+      logError('Error adding city:', error);
       return false;
     }
   };
@@ -139,12 +125,7 @@ export const useCustomCities = () => {
       });
       return true;
     } catch (error: any) {
-      console.error('Error removing custom city:', error);
-      toast({
-        title: "Error removing city",
-        description: error.message,
-        variant: "destructive",
-      });
+      logError('Error removing city:', error);
       return false;
     }
   };

--- a/src/hooks/useFinance.tsx
+++ b/src/hooks/useFinance.tsx
@@ -4,6 +4,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from './useAuth';
 import { useApiProxy } from './useApiProxy';
 import { useToast } from './use-toast';
+import { logError } from '@/lib/logError';
 
 interface StockData {
   symbol: string;
@@ -105,13 +106,13 @@ export const useFinance = () => {
             volume: parseInt(quote['06. volume']),
           });
         } else {
-          console.error(
+          logError(
             `Error fetching stock data for ${symbol}: Invalid response`,
             response
           );
         }
       } else {
-        console.error(
+        logError(
           `Error fetching stock data for ${symbol}:`,
           result.reason
         );
@@ -151,7 +152,7 @@ export const useFinance = () => {
         });
       }
     } catch (error) {
-      console.error('Error fetching crypto data:', error);
+      logError('Error fetching crypto data:', error);
     }
     
     return [];

--- a/src/hooks/useHoustonTraffic.tsx
+++ b/src/hooks/useHoustonTraffic.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import { logError } from '@/lib/logError';
 
 interface TrafficIncident {
   id: string;
@@ -57,7 +58,7 @@ export const useHoustonTraffic = () => {
       if (error) throw error;
       setTrafficIncidents((data || []) as TrafficIncident[]);
     } catch (err) {
-      console.error('Error fetching traffic incidents:', err);
+      logError('Error fetching traffic incidents:', err);
       setError(err instanceof Error ? err.message : 'Failed to fetch traffic data');
     } finally {
       setIsLoadingTraffic(false);
@@ -79,7 +80,7 @@ export const useHoustonTraffic = () => {
       if (error) throw error;
       setMetroAlerts((data || []) as MetroAlert[]);
     } catch (err) {
-      console.error('Error fetching Metro alerts:', err);
+      logError('Error fetching Metro alerts:', err);
       setError(err instanceof Error ? err.message : 'Failed to fetch Metro data');
     } finally {
       setIsLoadingMetro(false);
@@ -108,7 +109,7 @@ export const useHoustonTraffic = () => {
       
       setLastUpdated(new Date());
     } catch (err) {
-      console.error('Error refreshing traffic data:', err);
+      logError('Error refreshing traffic data:', err);
       setError(err instanceof Error ? err.message : 'Failed to refresh traffic data');
     }
   };

--- a/src/hooks/useLayoutConfig.tsx
+++ b/src/hooks/useLayoutConfig.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useAuth } from './useAuth';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
+import { logError } from '@/lib/logError';
 
 export interface WidgetConfig {
   id: string;
@@ -59,7 +60,7 @@ export const useLayoutConfig = () => {
           .maybeSingle();
 
         if (error) {
-          console.error('Error loading layout config:', error);
+          logError('Error loading layout config:', error);
           setLayoutConfig(defaultLayout);
         } else if (data && (data as any).dashboard_layout) {
           const config = (data as any).dashboard_layout as unknown as LayoutConfig;
@@ -104,7 +105,7 @@ export const useLayoutConfig = () => {
           setLayoutConfig(defaultLayout);
         }
       } catch (error) {
-        console.error('Error loading layout config:', error);
+        logError('Error loading layout config:', error);
         setLayoutConfig(defaultLayout);
       } finally {
         setIsLoading(false);
@@ -148,12 +149,7 @@ export const useLayoutConfig = () => {
         description: "Your dashboard layout has been saved.",
       });
     } catch (error: any) {
-      console.error('Error saving layout:', error);
-      toast({
-        title: "Error saving layout",
-        description: error?.message || "Failed to save your dashboard layout.",
-        variant: "destructive",
-      });
+      logError('Error saving layout:', error);
     } finally {
       setIsSaving(false);
     }

--- a/src/hooks/useSports.tsx
+++ b/src/hooks/useSports.tsx
@@ -3,6 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from './useAuth';
 import { useApiProxy } from './useApiProxy';
 import { useToast } from '@/hooks/use-toast';
+import { logError } from '@/lib/logError';
 
 interface SportsData {
   idEvent: string;
@@ -76,7 +77,7 @@ export const useSports = () => {
         .limit(1);
       
       if (error) {
-        console.error('Error fetching sports config:', error);
+        logError('Error fetching sports config:', error);
         return defaultConfig;
       }
       
@@ -187,7 +188,7 @@ export const useSports = () => {
             allEvents.push(...events);
           }
         } catch (error) {
-          console.error(`Error fetching ${league} data:`, error);
+          logError(`Error fetching ${league} data:`, error);
           // Continue with other leagues even if one fails
         }
       }
@@ -200,7 +201,7 @@ export const useSports = () => {
         .sort((a, b) => new Date(a.dateEvent).getTime() - new Date(b.dateEvent).getTime())
         .slice(0, 20);
     } catch (error) {
-      console.error('Error fetching sports data:', error);
+      logError('Error fetching sports data:', error);
     }
     
     return [];
@@ -249,7 +250,7 @@ export const useSports = () => {
         return standings.slice(0, 10);
       }
     } catch (error) {
-      console.error(`Error fetching ${league} standings:`, error);
+      logError(`Error fetching ${league} standings:`, error);
     }
     
     return [];

--- a/src/hooks/useStockIndices.tsx
+++ b/src/hooks/useStockIndices.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useApiProxy } from './useApiProxy';
+import { logError } from '@/lib/logError';
 
 interface IndexData {
   symbol: string;
@@ -56,7 +57,7 @@ export const useStockIndices = () => {
           }
         }
       } catch (error) {
-        console.error(`Error fetching index data for ${index.symbol}:`, error);
+        logError(`Error fetching index data for ${index.symbol}:`, error);
       }
     }
     

--- a/src/hooks/useStockWatchlist.tsx
+++ b/src/hooks/useStockWatchlist.tsx
@@ -4,6 +4,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from './useAuth';
 import { useApiProxy } from './useApiProxy';
 import { useToast } from './use-toast';
+import { logError } from '@/lib/logError';
 
 interface WatchlistStock {
   id: string;
@@ -40,7 +41,7 @@ export const useStockWatchlist = () => {
         .limit(1);
       
       if (error) {
-        console.error('Error fetching watchlist:', error);
+        logError('Error fetching watchlist:', error);
         return [];
       }
       
@@ -81,7 +82,7 @@ export const useStockWatchlist = () => {
           });
         }
       } catch (error) {
-        console.error(`Error fetching price for ${symbol}:`, error);
+        logError(`Error fetching price for ${symbol}:`, error);
       }
     }
     

--- a/src/hooks/useTexasLonghorns.tsx
+++ b/src/hooks/useTexasLonghorns.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import { logError } from '@/lib/logError';
 
 interface LonghornsArticle {
   title: string;
@@ -31,7 +32,7 @@ export const useTexasLonghorns = () => {
       console.log('🏈 Longhorns data received:', data);
       return data;
     } catch (error) {
-      console.error('Error fetching Longhorns news:', error);
+      logError('Error fetching Longhorns news:', error);
       throw error;
     }
   };

--- a/src/lib/logError.ts
+++ b/src/lib/logError.ts
@@ -1,0 +1,12 @@
+import { toast } from "@/hooks/use-toast";
+
+export function logError(message: string, error?: unknown) {
+  console.error(message, error);
+  const title = message.endsWith(":") ? message.slice(0, -1) : message;
+  const description = error instanceof Error ? error.message : String(error ?? "");
+  toast({
+    title,
+    description,
+    variant: "destructive",
+  });
+}


### PR DESCRIPTION
## Summary
- add `logError` helper to log errors and show a destructive toast
- replace `console.error` usages in hooks with the new logger

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c71624ec8322b4801c3a8e539a8d