### PR TITLE
Add ErrorBoundary and wrap App with retry capability

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("Error caught by ErrorBoundary:", error, errorInfo);
+  }
+
+  private reset = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex min-h-screen flex-col items-center justify-center p-4 text-center">
+          <h2 className="mb-4 text-xl font-semibold">Something went wrong.</h2>
+          <Button onClick={this.reset}>Try again</Button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,13 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
+import ErrorBoundary from "./components/ErrorBoundary";
 import "./index.css";
 
 console.log("React version:", React.version);
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>,
+);


### PR DESCRIPTION
## Summary
- add ErrorBoundary component with componentDidCatch, fallback UI, and reset button
- wrap App in ErrorBoundary so runtime errors render fallback and allow retry

## Testing
- `npm run lint` (fails: 94 problems, 78 errors)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6cde36f888322801d9cd4e8499550