### PR TITLE
feat: lazy load large pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,12 +5,16 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/hooks/useAuth";
 import ProtectedRoute from "@/components/ProtectedRoute";
-import Index from "./pages/Index";
-import Auth from "./pages/Auth";
-import Profile from "./pages/Profile";
-import NewsDemo from "./pages/NewsDemo";
-import ApiHealthDashboard from "./components/admin/ApiHealthDashboard";
-import NotFound from "./pages/NotFound";
+import { lazy, Suspense } from "react";
+
+const Index = lazy(() => import("./pages/Index"));
+const Auth = lazy(() => import("./pages/Auth"));
+const Profile = lazy(() => import("./pages/Profile"));
+const NewsDemo = lazy(() => import("./pages/NewsDemo"));
+const ApiHealthDashboard = lazy(
+  () => import("./components/admin/ApiHealthDashboard"),
+);
+const NotFound = lazy(() => import("./pages/NotFound"));
 
 const queryClient = new QueryClient();
 
@@ -21,40 +25,48 @@ const App = () => (
         <Toaster />
         <Sonner />
         <BrowserRouter>
-          <Routes>
-            <Route path="/auth" element={<Auth />} />
-            <Route path="/" element={<Index />} />
-            <Route 
-              path="/profile" 
-              element={
-                <ProtectedRoute>
-                  <Profile />
-                </ProtectedRoute>
-              } 
-            />
-            <Route 
-              path="/admin/api-health" 
-              element={
-                <ProtectedRoute>
-                  <div className="min-h-screen bg-dashboard-bg p-6">
-                    <div className="max-w-7xl mx-auto">
-                      <ApiHealthDashboard />
+          <Suspense
+            fallback={
+              <div className="min-h-screen bg-dashboard-bg flex items-center justify-center">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              </div>
+            }
+          >
+            <Routes>
+              <Route path="/auth" element={<Auth />} />
+              <Route path="/" element={<Index />} />
+              <Route
+                path="/profile"
+                element={
+                  <ProtectedRoute>
+                    <Profile />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/admin/api-health"
+                element={
+                  <ProtectedRoute>
+                    <div className="min-h-screen bg-dashboard-bg p-6">
+                      <div className="max-w-7xl mx-auto">
+                        <ApiHealthDashboard />
+                      </div>
                     </div>
-                  </div>
-                </ProtectedRoute>
-              } 
-            />
-            <Route 
-              path="/demo/news" 
-              element={
-                <ProtectedRoute>
-                  <NewsDemo />
-                </ProtectedRoute>
-              } 
-            />
-            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-            <Route path="*" element={<NotFound />} />
-          </Routes>
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/demo/news"
+                element={
+                  <ProtectedRoute>
+                    <NewsDemo />
+                  </ProtectedRoute>
+                }
+              />
+              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </Suspense>
         </BrowserRouter>
       </TooltipProvider>
     </AuthProvider>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,7 +1,9 @@
-import Dashboard from './Dashboard';
 import { useAuth } from '@/hooks/useAuth';
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
+import { lazy, Suspense } from 'react';
+
+const Dashboard = lazy(() => import('./Dashboard'));
 
 const Index = () => {
   const { user, loading } = useAuth();
@@ -27,7 +29,17 @@ const Index = () => {
     );
   }
 
-  return <Dashboard />;
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-dashboard-bg flex items-center justify-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+        </div>
+      }
+    >
+      <Dashboard />
+    </Suspense>
+  );
 };
 
 export default Index;


### PR DESCRIPTION
## Summary
- load pages with React.lazy
- add Suspense fallbacks for lazy routes

## Testing
- `npm run lint` *(fails: Unexpected any...)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6ce7362d483228a48620958bb9f37